### PR TITLE
fix: incorrect file paths in .toc files

### DIFF
--- a/LibRangeCheck-3.0.toc
+++ b/LibRangeCheck-3.0.toc
@@ -12,4 +12,4 @@
 
 LibStub-1.0\LibStub.lua
 CallbackHandler-1.0\CallbackHandler-1.0.xml
-LibRangeCheck-2.0\LibRangeCheck-2.0.lua
+LibRangeCheck-3.0\LibRangeCheck-3.0.lua

--- a/LibRangeCheck-3.0_Vanilla.toc
+++ b/LibRangeCheck-3.0_Vanilla.toc
@@ -11,4 +11,4 @@
 
 LibStub-1.0\LibStub.lua
 CallbackHandler-1.0\CallbackHandler-1.0.xml
-LibRangeCheck-2.0\LibRangeCheck-2.0.lua
+LibRangeCheck-3.0\LibRangeCheck-3.0.lua

--- a/LibRangeCheck-3.0_Wrath.toc
+++ b/LibRangeCheck-3.0_Wrath.toc
@@ -11,4 +11,4 @@
 
 LibStub-1.0\LibStub.lua
 CallbackHandler-1.0\CallbackHandler-1.0.xml
-LibRangeCheck-2.0\LibRangeCheck-2.0.lua
+LibRangeCheck-3.0\LibRangeCheck-3.0.lua


### PR DESCRIPTION
Fix `2.0` => `3.0` in file names in .toc files for standalone installs.