### PR TITLE
fix min-range checker

### DIFF
--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -540,25 +540,7 @@ local checkers_Spell = setmetatable({}, {
     return func
   end,
 })
-local function createCheckers_SpellWithMin(fallbackSpell)
-  local checkers_SpellWithMin = setmetatable({}, {
-    __index = function(t, spellIdx)
-      local func = function(unit)
-        if IsSpellInRange(spellIdx, BOOKTYPE_SPELL, unit) == 1 then
-          return true
-        elseif fallbackSpell and IsSpellInRange(fallbackSpell, BOOKTYPE_SPELL, unit) == 1 then
-          return true, true
-        else
-          return false
-        end
-      end
-      t[spellIdx] = func
-      return func
-    end,
-  })
-  return checkers_SpellWithMin
-end
-
+local checkers_SpellWithMin = {} -- see getCheckerForSpellWithMinRange()
 local checkers_Item = setmetatable({}, {
   __index = function(t, item)
     local func = function(unit)
@@ -628,6 +610,46 @@ local function findSpellIdx(spellName)
   return nil
 end
 
+local function fixRange(range)
+  if range then
+    return math_floor(range + 0.5)
+  end
+end
+
+local function getSpellData(sid)
+  local name, _, _, _, minRange, range = GetSpellInfo(sid)
+  return name, fixRange(minRange), fixRange(range), findSpellIdx(name)
+end
+
+local function findMinRangeChecker(origMinRange, origRange, spellList)
+  for i = 1, #spellList do
+    local sid = spellList[i]
+    local name, minRange, range, spellIdx = getSpellData(sid)
+    if range and spellIdx and origMinRange <= range and range <= origRange and minRange == 0 then
+      return checkers_Spell[findSpellIdx]
+    end
+  end
+end
+
+local function getCheckerForSpellWithMinRange(spellIdx, minRange, range, spellList)
+  local checker = checkers_SpellWithMin[spellIdx]
+  if checker then
+    return checker
+  end
+  local minRangeChecker = findMinRangeChecker(minRange, range, spellList)
+  if minRangeChecker then
+    checker = function()
+      if IsSpellInRange(spellIdx, BOOKTYPE_SPELL, unit) == 1 then
+        return true
+      elseif minRangeChecker(unit) then
+        return true, true
+      end
+    end
+    checkers_SpellWithMin[spellIdx] = checker
+    return checker
+  end
+end
+
 -- minRange should be nil if there's no minRange, not 0
 local function addChecker(t, range, minRange, checker, info)
   local rc = { ["range"] = range, ["minRange"] = minRange, ["checker"] = checker, ["info"] = info }
@@ -659,33 +681,10 @@ local function createCheckerList(spellList, itemList, interactList)
   end
 
   if spellList then
-    local spellIdWithOutMinRange
-    -- Some spells have a minimum range, IsSpellInRange returns false for both being
-    -- too near and too far. To distinguish between those two cases, we determine a spell
-    -- without a min range and use that as a fallback
     for i = 1, #spellList do
       local sid = spellList[i]
-      local name, _, _, _, minRange, range = GetSpellInfo(sid)
-      local spellIdx = findSpellIdx(name)
+      local name, minRange, range, spellIdx = getSpellData(sid)
       if spellIdx and range then
-        minRange = math_floor(minRange + 0.5)
-        if minRange == 0 then
-          spellIdWithOutMinRange = spellIdx
-          break;
-        end
-      end
-    end
-
-    local checkers_SpellWithMin = createCheckers_SpellWithMin(spellIdWithOutMinRange)
-
-    for i = 1, #spellList do
-      local sid = spellList[i]
-      local name, _, _, _, minRange, range = GetSpellInfo(sid)
-      local spellIdx = findSpellIdx(name)
-      if spellIdx and range then
-        minRange = math_floor(minRange + 0.5)
-        range = math_floor(range + 0.5)
-
         -- print("### spell: " .. tostring(name) .. ", " .. tostring(minRange) .. " - " ..  tostring(range))
 
         if minRange == 0 then -- getRange() expects minRange to be nil in this case
@@ -697,8 +696,11 @@ local function createCheckerList(spellList, itemList, interactList)
         end
 
         if minRange then
-          addChecker(res, range, minRange, checkers_SpellWithMin[spellIdx], "spell:" .. sid .. ":" .. tostring(name))
-          addChecker(resInCombat, range, minRange, checkers_SpellWithMin[spellIdx], "spell:" .. sid .. ":" .. tostring(name))
+          local checker = getCheckerForSpellWithMinRange(spellIdx, minRange, range, spellList)
+          if checker then
+            addChecker(res, range, minRange, checker, "spell:" .. sid .. ":" .. tostring(name))
+            addChecker(resInCombat, range, minRange, checker, "spell:" .. sid .. ":" .. tostring(name))
+          end
         else
           addChecker(res, range, minRange, checkers_Spell[spellIdx], "spell:" .. sid .. ":" .. tostring(name))
           addChecker(resInCombat, range, minRange, checkers_Spell[spellIdx], "spell:" .. sid .. ":" .. tostring(name))

--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -40,7 +40,7 @@ License: MIT
 -- @class file
 -- @name LibRangeCheck-3.0
 local MAJOR_VERSION = "LibRangeCheck-3.0"
-local MINOR_VERSION = 3
+local MINOR_VERSION = 4
 
 local lib, oldminor = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
 if not lib then

--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -638,7 +638,7 @@ local function getCheckerForSpellWithMinRange(spellIdx, minRange, range, spellLi
   end
   local minRangeChecker = findMinRangeChecker(minRange, range, spellList)
   if minRangeChecker then
-    checker = function()
+    checker = function(unit)
       if IsSpellInRange(spellIdx, BOOKTYPE_SPELL, unit) == 1 then
         return true
       elseif minRangeChecker(unit) then


### PR DESCRIPTION
We should use a spell for min-range checking that has a minRange of 0 and has a range between the original spell's minRange and range. If no such spell exists, we should not use the spell with a minRange to avoid misleading results.