### PR TITLE
Update LibRangeCheck-3.0.lua

### DIFF
--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -88,7 +88,7 @@ local UnitClass = UnitClass
 local UnitRace = UnitRace
 local GetInventoryItemLink = GetInventoryItemLink
 local GetTime = GetTime
-local HandSlotId = GetInventorySlotInfo("HandsSlot")
+local HandSlotId = GetInventorySlotInfo("HANDSSLOT")
 local math_floor = math.floor
 local UnitIsVisible = UnitIsVisible
 


### PR DESCRIPTION
resolves a "Cannot assign `string` to parameter" warning. see
https://warcraft.wiki.gg/wiki/InventorySlotId