### PR TITLE
fix missing arg to findSpellIdx()

### DIFF
--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -40,7 +40,7 @@ License: MIT
 -- @class file
 -- @name LibRangeCheck-3.0
 local MAJOR_VERSION = "LibRangeCheck-3.0"
-local MINOR_VERSION = 6
+local MINOR_VERSION = 7
 
 local lib, oldminor = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
 if not lib then
@@ -628,7 +628,7 @@ local function findMinRangeChecker(origMinRange, origRange, spellList)
     local sid = spellList[i]
     local name, minRange, range, spellIdx = getSpellData(sid)
     if range and spellIdx and origMinRange <= range and range <= origRange and minRange == 0 then
-      return checkers_Spell[findSpellIdx]
+      return checkers_Spell[findSpellIdx(name)]
     end
   end
 end


### PR DESCRIPTION
In my previous PR I missed the name argument from findSpellIdx() call, this PR fixes that