### PR TITLE
Re-enable hostile range checking in combat.

### DIFF
--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -764,7 +764,7 @@ local function getRange(unit, noItems)
   local canAssist = UnitCanAssist("player", unit)
   if UnitIsDeadOrGhost(unit) then
     if canAssist then
-      return getRangeWithCheckerList(unit, InCombatLockdownRestriction(unit, false) and lib.resRCInCombat or lib.resRC)
+      return getRangeWithCheckerList(unit, InCombatLockdownRestriction(unit) and lib.resRCInCombat or lib.resRC)
     else
       return getRangeWithCheckerList(unit, InCombatLockdownRestriction(unit) and lib.miscRCInCombat or lib.miscRC)
     end
@@ -793,7 +793,7 @@ local function getRange(unit, noItems)
       end
     end
   elseif canAssist then
-    if InCombatLockdownRestriction(unit, false) then
+    if InCombatLockdownRestriction(unit) then
       return getRangeWithCheckerList(unit, noItems and lib.friendNoItemsRCInCombat or lib.friendRCInCombat)
     else
       return getRangeWithCheckerList(unit, noItems and lib.friendNoItemsRC or lib.friendRC)


### PR DESCRIPTION
Here is a draft that re-enables hostile enemy range-checking in combat.  It updates the InCombatLockdown to include a unit check and has a hackish `canAttack` flag that can be used to avoid redundant `UnitCanAttack` checks.  There's probably a more clever way to accomplish the same thing and/or cache UnitCanAttack calls.

Results of `:GetRange(unit)` out of combat:
![image](https://github.com/WeakAuras/LibRangeCheck-3.0/assets/9438134/7fbf7107-2fbe-4f07-83f5-854b7ad96ef9)

- You can see that both hostile (`true`) and friendly (`false`) enemies have detailed range checks out of combat.

Results of `:GetRange(unit)` in combat:
![image](https://github.com/WeakAuras/LibRangeCheck-3.0/assets/9438134/eb52ea23-40b1-4686-a415-59420a466d2c)

- Friendly enemy ranges drop back to the level of granularity allowed by Blizzard.

In my (minimal) testing, no taint warnings have been generated.