### PR TITLE
Improve Item request processing

### DIFF
--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -675,7 +675,7 @@ local function createCheckerList(spellList, itemList, interactList)
     for range, items in pairs(itemList) do
       for i = 1, #items do
         local item = items[i]
-        if GetItemInfo(item) then
+        if Item:CreateFromItemID(item):IsItemDataCached() and GetItemInfo(item) then
           addChecker(res, range, nil, checkers_Item[item], "item:" .. item)
           break
         end
@@ -1259,7 +1259,7 @@ function lib:processItemRequests(itemRequests)
       if not i then
         itemRequests[range] = nil
         break
-      elseif self.failedItemRequests[item] then
+      elseif Item:CreateFromItemID(item):IsItemEmpty() or self.failedItemRequests[item] then
         -- print("### processItemRequests: failed: " .. tostring(item))
         tremove(items, i)
       elseif pendingItemRequest[item] and GetTime() < itemRequestTimeoutAt[item] then

--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -40,7 +40,7 @@ License: MIT
 -- @class file
 -- @name LibRangeCheck-3.0
 local MAJOR_VERSION = "LibRangeCheck-3.0"
-local MINOR_VERSION = 9
+local MINOR_VERSION = 10
 
 ---@class lib
 local lib, oldminor = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)


### PR DESCRIPTION
Currently the addon isn't correctly tracking when an item doesn't exist. This is causing an excessive number of item info queries when logging in, since the same items are being checked repeatedly.

Testing was done on Classic Era, logging in for the first time after restarting the game.
Before changes, I recorded 242 GET_ITEM_INFO_RECEIVED events over ~85 seconds when the addon loads.
After changes, I recorded 30 GET_ITEM_INFO_RECEIVED events over ~5 seconds when the addon loads.

I've also tested changes on Wrath, but not Retail. As far as I know, the ItemMixin API is unchanged in all game versions.