### PR TITLE
ShowAllSpellRanks causing range to be invalid when toggled.

### DIFF
--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -40,7 +40,7 @@ License: MIT
 -- @class file
 -- @name LibRangeCheck-3.0
 local MAJOR_VERSION = "LibRangeCheck-3.0"
-local MINOR_VERSION = 12
+local MINOR_VERSION = 13
 
 ---@class lib
 local lib, oldminor = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
@@ -1676,7 +1676,7 @@ function lib:activate()
     frame:RegisterEvent("CHARACTER_POINTS_CHANGED")
     frame:RegisterEvent("SPELLS_CHANGED")
 
-    if not isRetail then
+    if isEra or isWrath then
       frame:RegisterEvent("CVAR_UPDATE")
     end
 

--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -1224,6 +1224,12 @@ function lib:SPELLS_CHANGED()
   self:scheduleInit()
 end
 
+function lib:CVAR_UPDATE(_, cvar)
+  if cvar == "ShowAllSpellRanks" then
+    self:scheduleInit()
+  end
+end
+
 function lib:UNIT_INVENTORY_CHANGED(event, unit)
   if self.initialized and unit == "player" and self.handSlotItem ~= GetInventoryItemLink("player", HandSlotId) then
     self:scheduleInit()
@@ -1669,6 +1675,10 @@ function lib:activate()
     frame:RegisterEvent("LEARNED_SPELL_IN_TAB")
     frame:RegisterEvent("CHARACTER_POINTS_CHANGED")
     frame:RegisterEvent("SPELLS_CHANGED")
+
+    if not isRetail then
+      frame:RegisterEvent("CVAR_UPDATE")
+    end
 
     if isRetail or isWrath then
       frame:RegisterEvent("PLAYER_TALENT_UPDATE")


### PR DESCRIPTION
Loading in Range works fine with or without the Spell Ranks checked in the Spellbook.  However, when you toggle this the range returned is not valid/correct.  If you click the toggle twice it goes back to normal.  I think we probably just need to reinitialize the spells when this happens to prevent invalid Range.

Was tested on Classic Era: [Show All Spell Ranks breaking Range lib when toggled after loading in
](https://github.com/tukui-org/ElvUI/commit/840132dfe7c4c4c58bbd251020bf7f3d0c6a4c82)