### PR TITLE
fix to min range failing when you use no items

### DIFF
--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -596,7 +596,7 @@ local checkers_SpellWithMin = setmetatable({}, {
       local func = function(unit, skipInCombatCheck)
         if isInteract then
           local interactCheck = checkers_Interact[id]
-          if interactCheck(unit, skipInCombatCheck) then
+          if interactCheck and interactCheck(unit, skipInCombatCheck) then
             return true
           end
         else

--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -40,9 +40,7 @@ License: MIT
 -- @class file
 -- @name LibRangeCheck-3.0
 local MAJOR_VERSION = "LibRangeCheck-3.0"
-local MINOR_VERSION = 13
-
--- GLOBALS: LibStub, CreateFrame
+local MINOR_VERSION = 14
 
 ---@class lib
 local lib, oldminor = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)

--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -606,7 +606,7 @@ local checkers_SpellWithMin = setmetatable({}, {
           elseif t.MinInteractList then -- fallback to try interact when a spell failed
             for index in pairs(t.MinInteractList) do
               local interactCheck = checkers_Interact[index]
-              if interactCheck(unit, skipInCombatCheck) then
+              if interactCheck and interactCheck(unit, skipInCombatCheck) then
                 return true
               end
             end


### PR DESCRIPTION
- this implements the fix for https://github.com/WeakAuras/LibRangeCheck-3.0/issues/16 which happens when you call the lib with using `noItems` to handle Hunter, Warrior, and Rogue better with some of their MinRange spells.  it falls back to the interact state (allowing the spell min to pass for that spell, which may not be the intention, if you wanted range to fail within 8 for example on Hunter); ignoring its actual min range value but returning the actual range (the range number values returned are still correct as you get closer or go further away).

- this PR also improves the range returns for classes that do have min range spells by also including the interact returns; warriors only adding 1 interact return (to keep the return at distance of Charge at range 25, instead of Follow at range 28, unless they have Throw at range 30. `displayed in the video`)

- the video print statement includes the value of `#checkerList`, the `lo` value and its `info` of the spell being checked currently, and the `hi` value and its `range` value (in that order) for warrior on Classic PTR within function `getRangeWithCheckerList`

- this PR also includes a few tiny changes that don't change functionality (except for `FriendColor` and `HarmColor` actually existing) but it's something i had in our copy, i hope these can also be accepted so it's identical to the mainstream.


https://github.com/WeakAuras/LibRangeCheck-3.0/assets/2266754/75211612-d9a9-42b2-ab06-7f9413bca9a4

