### PR TITLE
Fix spell checkers on Classic/SOD

### DIFF
--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -40,7 +40,7 @@ License: MIT
 -- @class file
 -- @name LibRangeCheck-3.0
 local MAJOR_VERSION = "LibRangeCheck-3.0"
-local MINOR_VERSION = 13
+local MINOR_VERSION = 14
 
 ---@class lib
 local lib, oldminor = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
@@ -624,7 +624,7 @@ local function getSpellData(sid)
   return name, fixRange(minRange), fixRange(range), findSpellIdx(name)
 end
 
-local function findMinRangeChecker(origMinRange, origRange, spellList)
+local function findMinRangeChecker(origMinRange, origRange, spellList, interactLists)
   for i = 1, #spellList do
     local sid = spellList[i]
     local name, minRange, range, spellIdx = getSpellData(sid)
@@ -632,14 +632,19 @@ local function findMinRangeChecker(origMinRange, origRange, spellList)
       return checkers_Spell[findSpellIdx(name)]
     end
   end
+  for index, range in pairs(interactLists) do
+    if origMinRange <= range and range <= origRange then
+      return checkers_Interact[index]
+    end
+  end
 end
 
-local function getCheckerForSpellWithMinRange(spellIdx, minRange, range, spellList)
+local function getCheckerForSpellWithMinRange(spellIdx, minRange, range, spellList, interactLists)
   local checker = checkers_SpellWithMin[spellIdx]
   if checker then
     return checker
   end
-  local minRangeChecker = findMinRangeChecker(minRange, range, spellList)
+  local minRangeChecker = findMinRangeChecker(minRange, range, spellList, interactLists)
   if minRangeChecker then
     checker = function(unit)
       if IsSpellInRange(spellIdx, BOOKTYPE_SPELL, unit) == 1 then
@@ -683,6 +688,12 @@ local function createCheckerList(spellList, itemList, interactList)
     end
   end
 
+  if interactList and not next(res) then
+    for index, range in pairs(interactList) do
+      addChecker(res, range, nil, checkers_Interact[index], "interact:" .. index)
+    end
+  end
+
   if spellList then
     for i = 1, #spellList do
       local sid = spellList[i]
@@ -699,7 +710,7 @@ local function createCheckerList(spellList, itemList, interactList)
         end
 
         if minRange then
-          local checker = getCheckerForSpellWithMinRange(spellIdx, minRange, range, spellList)
+          local checker = getCheckerForSpellWithMinRange(spellIdx, minRange, range, spellList, interactList)
           if checker then
             addChecker(res, range, minRange, checker, "spell:" .. sid .. ":" .. tostring(name))
             addChecker(resInCombat, range, minRange, checker, "spell:" .. sid .. ":" .. tostring(name))
@@ -709,12 +720,6 @@ local function createCheckerList(spellList, itemList, interactList)
           addChecker(resInCombat, range, minRange, checkers_Spell[spellIdx], "spell:" .. sid .. ":" .. tostring(name))
         end
       end
-    end
-  end
-
-  if interactList and not next(res) then
-    for index, range in pairs(interactList) do
-      addChecker(res, range, nil, checkers_Interact[index], "interact:" .. index)
     end
   end
 


### PR DESCRIPTION
Sspells with have a min range, e.g. a spell with an 8-30y range, cannot be easily used of range checking, because if it isn't in range, that could be <8 or >30. Thus we used a second checker to distinguish between those two cases.

Previously only other spells would be consider, but in some cases classes have no spells that can fill that gap.

Thus use an idea by kodewdle to fall-back to the interact list. All we need is an interact distance that is bigger than min range and less than the max range.

Fixes: #16