### PR TITLE
Fix error with IsSpellBookItemInRange when loadDepractionFallbacks cvar is enable

### DIFF
--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -40,7 +40,7 @@ License: MIT
 -- @class file
 -- @name LibRangeCheck-3.0
 local MAJOR_VERSION = "LibRangeCheck-3.0"
-local MINOR_VERSION = 19
+local MINOR_VERSION = 20
 
 ---@class lib
 local lib, oldminor = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
@@ -86,6 +86,10 @@ local IsSpellInRange = _G.IsSpellInRange or function(id, unit)
   return nil
 end
 local IsSpellBookItemInRange = _G.IsSpellInRange or function(index, spellBank, unit)
+  -- Deprecated_11_0_0.lua set BOOKTYPE_SPELL to "spell" but doesn't provide a compatibility wrapper for IsSpellBookItemInRange
+  if type(spellBank) == "string" then
+    spellBank = (spellBank == "spell") and Enum.SpellBookSpellBank.Player or Enum.SpellBookSpellBank.Pet;
+  end
   local result = C_SpellBook.IsSpellBookItemInRange(index, spellBank, unit)
   if result == true then
     return 1


### PR DESCRIPTION
At https://github.com/Gethe/wow-ui-source/blob/a2be406dbd035af8d82716449610aba97090ffe3/Interface/AddOns/Blizzard_Deprecated/Deprecated_11_0_0.lua#L46 BOOKTYPE_SPELL is set to "spell", but the file doesn't provide a wrapper for IsSpellInRange