### PR TITLE
Added Barbed Shot to make 40 yard check work while in combat for beast mastery hunters

### DIFF
--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -207,6 +207,7 @@ tinsert(ResSpells.DRUID, 20484) -- Rebirth (40 yards, level 29)
 
 -- Hunters
 tinsert(HarmSpells.HUNTER, 75) -- Auto Shot (40 yards)
+tinsert(HarmSpells.HUNTER, 217200) -- Barbed Shot (40 yards), no for Beast Mastery
 
 if not isRetail then
   tinsert(HarmSpells.HUNTER, 2764) -- Throw (30 yards, level 1)


### PR DESCRIPTION
Found out there are currently no available range checks when using :GetHarmCheckers(true) for beast mastery hunters on retail so
I added Barbed Shot to make 40 yard check work while in combat for beast mastery hunters