### PR TITLE
Add Black Arrow for Dark Ranger Hunter.

### DIFF
--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -40,7 +40,7 @@ License: MIT
 -- @class file
 -- @name LibRangeCheck-3.0
 local MAJOR_VERSION = "LibRangeCheck-3.0"
-local MINOR_VERSION = 27
+local MINOR_VERSION = 28
 
 ---@class lib
 local lib, oldminor = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
@@ -206,6 +206,7 @@ tinsert(ResSpells.DRUID, 50769) -- Revive (40 yards, level 14)
 tinsert(ResSpells.DRUID, 20484) -- Rebirth (40 yards, level 29)
 
 -- Hunters
+tinsert(HarmSpells.HUNTER, 466930) -- Black Arrow (40 yards)
 tinsert(HarmSpells.HUNTER, 75) -- Auto Shot (40 yards)
 
 if not isRetail then


### PR DESCRIPTION
Dark Ranger hero talent "Bleak Arrows" will unlearn Auto Shot and not provide any replacement spell. Black Arrow can be used instead, as it is learned with DR.

![image](https://github.com/user-attachments/assets/dea25670-2dde-4fb0-9cf3-7866f255c7d0)
