### PR TITLE
Fix: Titan event registration and use C_EventUtils.IsEventValid

### DIFF
--- a/LibRangeCheck-3.0.toc
+++ b/LibRangeCheck-3.0.toc
@@ -1,4 +1,4 @@
-## Interface: 110207, 120000, 120001
+## Interface: 120001, 120005
 ## Title: Lib: RangeCheck-3.0
 ## Notes: A library to determine estimated range.
 ## Author: The WoWUIDev Community

--- a/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
+++ b/LibRangeCheck-3.0/LibRangeCheck-3.0.lua
@@ -40,7 +40,7 @@ License: MIT
 -- @class file
 -- @name LibRangeCheck-3.0
 local MAJOR_VERSION = "LibRangeCheck-3.0"
-local MINOR_VERSION = 33
+local MINOR_VERSION = 34
 
 ---@class lib
 local lib, oldminor = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
@@ -53,6 +53,7 @@ local interfaceVersion = select(4, GetBuildInfo())
 local isRetail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
 local isEra = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
 local isTBC = WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC
+local isWrath = WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC
 local isCata = WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC
 local isMidnight = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE and interfaceVersion >= 120000
 
@@ -4951,18 +4952,19 @@ function lib:activate()
     local frame = CreateFrame("Frame")
     self.frame = frame
 
-    if not (isMidnight or isTBC) then
-      frame:RegisterEvent("LEARNED_SPELL_IN_TAB")
-    end
     frame:RegisterEvent("CHARACTER_POINTS_CHANGED")
     frame:RegisterEvent("SPELLS_CHANGED")
 
-    if isEra or isCata then
-      frame:RegisterEvent("CVAR_UPDATE")
+    if C_EventUtils and C_EventUtils.IsEventValid("LEARNED_SPELL_IN_TAB") then
+      frame:RegisterEvent("LEARNED_SPELL_IN_TAB")
     end
 
-    if isRetail or isCata then
+    if C_EventUtils and C_EventUtils.IsEventValid("PLAYER_TALENT_UPDATE") then
       frame:RegisterEvent("PLAYER_TALENT_UPDATE")
+    end
+
+    if (isEra or isTBC or isWrath or isCata) then
+      frame:RegisterEvent("CVAR_UPDATE")
     end
 
     local _, playerClass = UnitClass("player")

--- a/LibRangeCheck-3.0_Wrath.toc
+++ b/LibRangeCheck-3.0_Wrath.toc
@@ -1,4 +1,4 @@
-## Interface: 30405, 38000
+## Interface: 30405, 38001
 ## Title: Lib: RangeCheck-3.0
 ## Notes: A library to determine estimated range.
 ## Author: The WoWUIDev Community


### PR DESCRIPTION
Titan no longer has the LEARNED_SPELL_IN_TAB event
Switched to C_EventUtils.IsEventValid across all expansions to prevent lua errors on titan and future lua errors
Fixed CVAR_UPDATE registration
TOC Bumps

Error:
```
Message: Frame:RegisterEvent(): Frame:RegisterEvent(): Attempt to register unknown event "LEARNED_SPELL_IN_TAB"
Time: Thu Apr  9 05:31:45 2026
Count: 1
Stack:
[Interface/AddOns/WeakAuras/Libs/LibRangeCheck-3.0/LibRangeCheck-3.0.lua]:4599: in function '?'
[Interface/AddOns/WeakAuras/Libs/LibRangeCheck-3.0/LibRangeCheck-3.0.lua]:4665: in main chunk

Locals:
self = <table> {
 friendNoItemsRC = <table> {
 }
 harmNoItemsRC = <table> {
 }
 frame = Frame {
 }
 miscRCInCombat = <table> {
 }
 friendRCInCombat = <table> {
 }
 MeleeRange = 2
 friendNoItemsRCInCombat = <table> {
 }
 checkerCache_Spell = <table> {
 }
 miscRC = <table> {
 }
 petRC = <table> {
 }
 checkerCache_Item = <table> {
 }
 friendRC = <table> {
 }
 harmRC = <table> {
 }
 petRCInCombat = <table> {
 }
 resRC = <table> {
 }
 harmRCInCombat = <table> {
 }
 resRCInCombat = <table> {
 }
 failedItemRequests = <table> {
 }
 CHECKERS_CHANGED = "CHECKERS_CHANGED"
 harmNoItemsRCInCombat = <table> {
 }
}
frame = Frame {
}
isMidnight = false
isTBC = false
isEra = false
isCata = false
isRetail = false
lastUpdate = 0
UpdateDelay = 0.500000
```